### PR TITLE
Feat: introduced arbitration cost multiplier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 INFURA_API_KEY='<api key>'
-PRIVATE_KEY='<private key>'
+PRIVATE_KEYS='{42: <private key>, 1: <private key>}'

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -16,6 +16,8 @@ task("accounts", "Prints the list of accounts", async (_, {ethers}) => {
   }
 });
 
+const PRIVATE_KEYS = JSON.parse(process.env.PRIVATE_KEYS);
+
 // You have to export an object to set up your config
 // This object can have the following optional entries:
 // defaultNetwork, networks, solc, and paths.
@@ -41,7 +43,7 @@ module.exports = {
     kovan: {
       chainId: 42,
       url: `https://kovan.infura.io/v3/${process.env.INFURA_API_KEY}`,
-      accounts: [process.env.PRIVATE_KEY],
+      accounts: [PRIVATE_KEYS[42]],
       live: true,
       saveDeployments: true,
       tags: ["staging"],
@@ -49,7 +51,7 @@ module.exports = {
     mainnet: {
       chainId: 1,
       url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
-      accounts: [process.env.PRIVATE_KEY],
+      accounts: [PRIVATE_KEYS[1]],
       live: true,
       saveDeployments: true,
       tags: ["production"],

--- a/contracts/0.7.x/Linguo.sol
+++ b/contracts/0.7.x/Linguo.sol
@@ -1,6 +1,6 @@
 /**
  * @authors: [@unknownunknown1, @hbarcelos]
- * @reviewers: [@fnanni-0*, @nix1g*]
+ * @reviewers: [@fnanni-0*, @nix1g]
  * @auditors: []
  * @bounties: []
  * @deployments: []

--- a/contracts/0.7.x/Linguo.sol
+++ b/contracts/0.7.x/Linguo.sol
@@ -1,6 +1,6 @@
 /**
  * @authors: [@unknownunknown1, @hbarcelos]
- * @reviewers: [@fnanni-0*, @nix1g]
+ * @reviewers: [@fnanni-0, @nix1g]
  * @auditors: []
  * @bounties: []
  * @deployments: []

--- a/contracts/0.7.x/Linguo.sol
+++ b/contracts/0.7.x/Linguo.sol
@@ -1,6 +1,6 @@
 /**
  * @authors: [@unknownunknown1, @hbarcelos]
- * @reviewers: [@fnanni-0, @nix1g]
+ * @reviewers: [@fnanni-0*, @nix1g*]
  * @auditors: []
  * @bounties: []
  * @deployments: []
@@ -64,7 +64,8 @@ contract Linguo is IArbitrable, IEvidence {
     bytes public arbitratorExtraData; // Extra data to allow creating a dispute on the arbitrator.
     uint256 public reviewTimeout; // Time in seconds, during which the submitted translation can be challenged.
     // All multipliers below are in basis points.
-    uint256 public translationMultiplier; // Multiplier for calculating the value of the deposit translator must pay to self-assign a task.
+    uint256 public arbitrationCostMultiplier; // Multiplier for calculating the arbitration cost related part of the deposit translator must pay to self-assign a task.
+    uint256 public translationMultiplier; // Multiplier for calculating the task price related part of the deposit translator must pay to self-assign a task.
     uint256 public challengeMultiplier; // Multiplier for calculating the value of the deposit challenger must pay to challenge a translation.
     uint256 public sharedStakeMultiplier; // Multiplier for calculating the appeal fee that must be paid by the submitter in the case where there isn't a winner and loser (e.g. when the arbitrator ruled "refuse to arbitrate").
     uint256 public winnerStakeMultiplier; // Multiplier for calculating the appeal fee of the party that won the previous round.
@@ -152,6 +153,7 @@ contract Linguo is IArbitrable, IEvidence {
         IArbitrator _arbitrator,
         bytes memory _arbitratorExtraData,
         uint256 _reviewTimeout,
+        uint256 _arbitrationCostMultiplier,
         uint256 _translationMultiplier,
         uint256 _challengeMultiplier,
         uint256 _sharedStakeMultiplier,
@@ -161,6 +163,7 @@ contract Linguo is IArbitrable, IEvidence {
         arbitrator = _arbitrator;
         arbitratorExtraData = _arbitratorExtraData;
         reviewTimeout = _reviewTimeout;
+        arbitrationCostMultiplier = _arbitrationCostMultiplier;
         translationMultiplier = _translationMultiplier;
         challengeMultiplier = _challengeMultiplier;
         sharedStakeMultiplier = _sharedStakeMultiplier;
@@ -186,7 +189,14 @@ contract Linguo is IArbitrable, IEvidence {
         reviewTimeout = _reviewTimeout;
     }
 
-    /** @dev Changes the multiplier for translators' deposit.
+    /** @dev Changes the multiplier for the arbitration cost part of the translators' deposit.
+     *  @param _arbitrationCostMultiplier A new value of the multiplier for calculating translator's deposit. In basis points.
+     */
+    function changeArbitrationCostMultiplier(uint256 _arbitrationCostMultiplier) public onlyGovernor {
+        arbitrationCostMultiplier = _arbitrationCostMultiplier;
+    }
+
+    /** @dev Changes the multiplier for the task price part of translators' deposit.
      *  @param _translationMultiplier A new value of the multiplier for calculating translator's deposit. In basis points.
      */
     function changeTranslationMultiplier(uint256 _translationMultiplier) public onlyGovernor {
@@ -265,7 +275,9 @@ contract Linguo is IArbitrable, IEvidence {
             ((task.maxPrice - task.minPrice) * (block.timestamp - task.lastInteraction)) /
             task.submissionTimeout;
         uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
-        uint256 translatorDeposit = arbitrationCost.addCap((translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR);
+        uint256 translatorDeposit = arbitrationCost.mulCap(1 + (arbitrationCostMultiplier / MULTIPLIER_DIVISOR)).addCap(
+            (translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR
+        );
 
         require(task.status == Status.Created, "Task has already been assigned or reimbursed.");
         require(msg.value >= translatorDeposit, "Not enough ETH to reach the required deposit value.");
@@ -647,7 +659,9 @@ contract Linguo is IArbitrable, IEvidence {
                 ((task.maxPrice - task.minPrice) * (block.timestamp - task.lastInteraction)) /
                 task.submissionTimeout;
             uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
-            deposit = arbitrationCost.addCap((translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR);
+            deposit = arbitrationCost.mulCap(1 + (arbitrationCostMultiplier / MULTIPLIER_DIVISOR)).addCap(
+                (translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR
+            );
         }
     }
 

--- a/contracts/0.7.x/Linguo.sol
+++ b/contracts/0.7.x/Linguo.sol
@@ -275,7 +275,7 @@ contract Linguo is IArbitrable, IEvidence {
             ((task.maxPrice - task.minPrice) * (block.timestamp - task.lastInteraction)) /
             task.submissionTimeout;
         uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
-        uint256 translatorDeposit = arbitrationCost.mulCap(1 + (arbitrationCostMultiplier / MULTIPLIER_DIVISOR)).addCap(
+        uint256 translatorDeposit = (arbitrationCost.mulCap(arbitrationCostMultiplier) / MULTIPLIER_DIVISOR).addCap(
             (translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR
         );
 
@@ -659,7 +659,7 @@ contract Linguo is IArbitrable, IEvidence {
                 ((task.maxPrice - task.minPrice) * (block.timestamp - task.lastInteraction)) /
                 task.submissionTimeout;
             uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
-            deposit = arbitrationCost.mulCap(1 + (arbitrationCostMultiplier / MULTIPLIER_DIVISOR)).addCap(
+            deposit = (arbitrationCost.mulCap(arbitrationCostMultiplier) / MULTIPLIER_DIVISOR).addCap(
                 (translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR
             );
         }

--- a/deploy/01-Linguo.js
+++ b/deploy/01-Linguo.js
@@ -15,6 +15,7 @@ const paramsByChainId = {
     arbitrator: "0xA8243657a1E6ad1AAf2b59c4CCDFE85fC6fD7a8B",
     // 1 day
     reviewTimeout: "86400",
+    arbitrationCostMultiplier: "0",
     translationMultiplier: "1000",
     challengeMultiplier: "0",
     sharedStakeMultiplier: "10000",
@@ -25,7 +26,8 @@ const paramsByChainId = {
     arbitrator: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069",
     // 1 week
     reviewTimeout: "604800",
-    translationMultiplier: "3500",
+    arbitrationCostMultiplier: "5000",
+    translationMultiplier: "2500",
     challengeMultiplier: "0",
     sharedStakeMultiplier: "5000",
     winnerStakeMultiplier: "5000",
@@ -41,6 +43,7 @@ async function deployLinguo({getNamedAccounts, getChainId, deployments}) {
   const {
     arbitrator,
     reviewTimeout,
+    arbitrationCostMultiplier,
     translationMultiplier,
     challengeMultiplier,
     sharedStakeMultiplier,
@@ -57,6 +60,7 @@ async function deployLinguo({getNamedAccounts, getChainId, deployments}) {
         arbitrator,
         arbitratorExtraData,
         reviewTimeout,
+        arbitrationCostMultiplier,
         translationMultiplier,
         challengeMultiplier,
         sharedStakeMultiplier,

--- a/deploy/01-Linguo.js
+++ b/deploy/01-Linguo.js
@@ -15,7 +15,7 @@ const paramsByChainId = {
     arbitrator: "0xA8243657a1E6ad1AAf2b59c4CCDFE85fC6fD7a8B",
     // 1 day
     reviewTimeout: "86400",
-    arbitrationCostMultiplier: "0",
+    arbitrationCostMultiplier: "10000",
     translationMultiplier: "1000",
     challengeMultiplier: "0",
     sharedStakeMultiplier: "10000",
@@ -26,7 +26,7 @@ const paramsByChainId = {
     arbitrator: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069",
     // 1 week
     reviewTimeout: "604800",
-    arbitrationCostMultiplier: "5000",
+    arbitrationCostMultiplier: "15000",
     translationMultiplier: "2500",
     challengeMultiplier: "0",
     sharedStakeMultiplier: "5000",

--- a/scripts/getDeployedAddresses.js
+++ b/scripts/getDeployedAddresses.js
@@ -14,7 +14,7 @@ async function main() {
       ),
     {}
   );
-  console.log(JSON.stringify(deployedAddresses, null, 2));
+  console.log(JSON.stringify(deployedAddresses));
 }
 
 main()

--- a/test/Linguo.test.js
+++ b/test/Linguo.test.js
@@ -35,8 +35,8 @@ describe("Linguo", function () {
   const arbitratorExtraData = "0x85";
   const appealTimeOut = 100;
   const reviewTimeout = 2400;
-  const arbitrationCostMultiplier = 1000;
-  const translationMultiplier = 1000;
+  const arbitrationCostMultiplier = 15000;
+  const translationMultiplier = 2500;
   const challengeMultiplier = 2000;
   const sharedMultiplier = 5000;
   const winnerMultiplier = 3000;
@@ -136,8 +136,9 @@ describe("Linguo", function () {
     assert(Math.abs(priceLinguo - price) <= price / 100, "Contract returns incorrect task price");
 
     price = Math.floor(taskMinPrice + ((taskMaxPrice - taskMinPrice) * secondsPassed) / submissionTimeout);
-    const deposit = arbitrationFee + (translationMultiplier * price) / MULTIPLIER_DIVISOR;
+    const deposit = (arbitrationFee * arbitrationCostMultiplier + translationMultiplier * price) / MULTIPLIER_DIVISOR;
     const depositLinguo = await linguo.getDepositValue(0);
+
     assert(
       Math.abs(depositLinguo.toNumber() - deposit) <= deposit / 100,
       "Contract returns incorrect required deposit"

--- a/test/Linguo.test.js
+++ b/test/Linguo.test.js
@@ -35,6 +35,7 @@ describe("Linguo", function () {
   const arbitratorExtraData = "0x85";
   const appealTimeOut = 100;
   const reviewTimeout = 2400;
+  const arbitrationCostMultiplier = 1000;
   const translationMultiplier = 1000;
   const challengeMultiplier = 2000;
   const sharedMultiplier = 5000;
@@ -62,6 +63,7 @@ describe("Linguo", function () {
       arbitrator.address,
       arbitratorExtraData,
       reviewTimeout,
+      arbitrationCostMultiplier,
       translationMultiplier,
       challengeMultiplier,
       sharedMultiplier,


### PR DESCRIPTION
The arbitration cost multiplier aims to avoid the issue of nobody willing to challenge a translation task with low payout due to the gas cost of challenging be too close to or higher than the reward available.

With the arbitration cost multiplier we increase the required translator deposit for low paying tasks so it can cope with a range of gas costs and still be profitable for challengers in case there is an issue with the translation.

Previously the translator deposit could be given by:

```
D = a + T*p

a: arbitration cost
T: the translator multiplier
p: the task price
```

On the updated version, the translator deposit is given by:
```
D = (1 + C)*a + T*p

C: the arbitration cost multiplier
a: arbitration cost
T: the translator multiplier
p: the task price
```

For tasks whose payout is low, the `(1 + C)*a` part will be dominant. For more expensive ones `T*p` will compose the majority of the deposit.

